### PR TITLE
Fixes the pool get_pair call in case the pair does not exist

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -8,8 +8,14 @@ use ethers::utils::GanacheInstance;
 
 use ethers::providers::Http;
 use forge_test::bindings::t_token::TToken;
-use forge_test::bindings::uniswap_v2_factory::UniswapV2Factory;
 use forge_test::bindings::uniswap_v2_router_02::UniswapV2Router02;
+
+abigen!(
+    UniV2Factory,
+    r#"[
+        function getPair(address tokenA, address tokenB) external view returns (address)
+    ]"#
+);
 
 // connects the private key to http://localhost:8545
 pub fn connect(ganache: &GanacheInstance, idx: usize) -> Arc<Provider<Http>> {
@@ -99,7 +105,12 @@ where
         .await
         .unwrap();
 
-    let factory_contract = UniswapV2Factory::new(factory.address(), client.clone());
-    let pool_address = factory_contract.get_pair(token, weth).call().await.unwrap();
+    let factory_contract = UniV2Factory::new(factory.address(), client.clone());
+    let pool_address = factory_contract
+        .get_pair(token, weth)
+        .call()
+        .await
+        .unwrap_or(H160::zero());
+
     (factory.address(), router.address(), pool_address)
 }

--- a/tests/simulation.rs
+++ b/tests/simulation.rs
@@ -111,7 +111,5 @@ mod simulation_test {
             .await
             .unwrap();
         dbg!(after_balance);
-
-        drop(ganache);
     }
 }

--- a/tests/simulation.rs
+++ b/tests/simulation.rs
@@ -70,6 +70,7 @@ mod simulation_test {
             provider.clone(),
         )
         .await;
+        dbg!(pool_a, pool_b);
 
         let pair_a = Reserve::new(token_balance_1, eth_balance_1);
         let pair_b = Reserve::new(token_balance_2, eth_balance_2);
@@ -88,6 +89,7 @@ mod simulation_test {
             .await
             .unwrap();
         dbg!(initial_balance);
+
         let arb = ArbitrageSwap::new(arb.address(), searcher.clone());
         arb.swap(
             pool_a,
@@ -109,5 +111,7 @@ mod simulation_test {
             .await
             .unwrap();
         dbg!(after_balance);
+
+        drop(ganache);
     }
 }


### PR DESCRIPTION
- if abigen! satisfies our needs, we can delete some of the bindings
- I believe the bug was due to create_pool calling to get a pair that did not exist, which returns 0x, and it could not decode it. If it returns 0x, I have added unwrap_or(H160::zero()) instead.
- added dbg for pool_a and pool_b
- added dropping of ganache at the end of the test

(we need another transaction in create pool to actually create a pool <- in absence of this, we would expect getPair to return address(0), which is what it does right now)